### PR TITLE
Allow passing files as info arrays instead of paths

### DIFF
--- a/src/FileFieldsTrait.php
+++ b/src/FileFieldsTrait.php
@@ -4,12 +4,16 @@ namespace Isign;
 trait FileFieldsTrait
 {
     /**
-     * Get file fields for API query
-     * @param string $path file path
+     * Get file fields for API query, if file path was used as opposed to a file data array.
+     * @param array|string $path file path
      * @return array
      */
     public function getFileFields($path)
     {
+        if (is_array($path)) {
+            return $path;
+        }
+
         if (!file_exists($path)) {
             throw new \RuntimeException(sprintf('File "%s" does not exist', $path));
         }

--- a/tests/Document/SealTest.php
+++ b/tests/Document/SealTest.php
@@ -23,9 +23,14 @@ class SealTest extends TestCase
     public function testGetFileFields()
     {
         $method = new Seal(
-            'pdf',
+            'asic',
             [
                 'files' => [
+                    [
+                        'name' => 'filename.pdf',
+                        'digest' => 'some digest',
+                        'content' => 'some content'
+                    ],
                     __DIR__.'/../data/document.pdf'
                 ]
             ],
@@ -33,13 +38,18 @@ class SealTest extends TestCase
         );
         $result = $method->getFields();
 
-        $this->assertArrayHasKey('pdf', $result);
-        $this->assertArrayHasKey('files', $result['pdf']);
-        $this->assertArrayHasKey(0, $result['pdf']['files']);
-        $file = $result['pdf']['files'][0];
-        $this->assertArrayHasKey('name', $file);
-        $this->assertArrayHasKey('digest', $file);
-        $this->assertArrayHasKey('content', $file);
+        $this->assertArrayHasKey('asic', $result);
+        $this->assertArrayHasKey('files', $result['asic']);
+        $this->assertArrayHasKey(0, $result['asic']['files']);
+        $file0 = $result['asic']['files'][0];
+        $this->assertArrayHasKey('name', $file0);
+        $this->assertArrayHasKey('digest', $file0);
+        $this->assertArrayHasKey('content', $file0);
+        $this->assertArrayHasKey(1, $result['asic']['files']);
+        $file1 = $result['asic']['files'][1];
+        $this->assertArrayHasKey('name', $file1);
+        $this->assertArrayHasKey('digest', $file1);
+        $this->assertArrayHasKey('content', $file1);
     }
 
     /**


### PR DESCRIPTION
For queries which send files to the service, this will allow passing them file information (filename, hash, content) instead of always requiring that file path is passed. While such arrays will not be checked for validity within the library, this allows for more flexibility when using it.